### PR TITLE
Fix macOS file open association and scroll sync

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "log",
  "notify",

--- a/src-tauri/src/commands/file_ops.rs
+++ b/src-tauri/src/commands/file_ops.rs
@@ -1,5 +1,7 @@
 use std::fs;
 
+use crate::PendingOpenFiles;
+
 #[tauri::command]
 pub async fn read_file(path: String) -> Result<String, String> {
     fs::read_to_string(&path).map_err(|e| format!("Failed to read file: {}", e))
@@ -18,6 +20,7 @@ pub async fn get_file_size(path: String) -> Result<u64, String> {
 }
 
 /// Returns the file path passed as a CLI argument (for file associations), if any.
+/// Works on Linux/Windows where the OS passes the file path via argv.
 #[tauri::command]
 pub async fn get_open_file_arg() -> Option<String> {
     let args: Vec<String> = std::env::args().collect();
@@ -29,4 +32,14 @@ pub async fn get_open_file_arg() -> Option<String> {
             None
         }
     })
+}
+
+/// Returns and drains any file paths received via macOS Apple Events (RunEvent::Opened)
+/// before the frontend was ready. Called by the frontend on init to handle cold-launch opens.
+#[tauri::command]
+pub async fn get_pending_open_file(state: tauri::State<'_, PendingOpenFiles>) -> Result<Option<String>, String> {
+    let mut pending = state.0.lock().unwrap();
+    let first = pending.first().cloned();
+    pending.clear();
+    Ok(first)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ mod commands;
 #[cfg(desktop)]
 mod platform;
 
+use tauri::Emitter;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let mut builder = tauri::Builder::default()
@@ -41,6 +43,17 @@ pub fn run() {
     }
 
     builder
-        .run(tauri::generate_context!())
-        .expect("error running Inkwell");
+        .build(tauri::generate_context!())
+        .expect("error building Inkwell")
+        .run(|app_handle, event| {
+            if let tauri::RunEvent::Opened { urls } = event {
+                for url in urls {
+                    if let Ok(path) = url.to_file_path() {
+                        if let Some(path_str) = path.to_str() {
+                            let _ = app_handle.emit("open-file-requested", path_str.to_string());
+                        }
+                    }
+                }
+            }
+        });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,12 @@ mod commands;
 #[cfg(desktop)]
 mod platform;
 
-use tauri::Emitter;
+use std::sync::Mutex;
+use tauri::{Emitter, Manager};
+
+/// Stores file paths received via macOS Apple Events (RunEvent::Opened)
+/// before the frontend is ready to handle them.
+pub struct PendingOpenFiles(pub Mutex<Vec<String>>);
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -11,6 +16,7 @@ pub fn run() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_store::Builder::default().build())
+        .manage(PendingOpenFiles(Mutex::new(Vec::new())))
         .invoke_handler(tauri::generate_handler![
             commands::file_ops::read_file,
             commands::file_ops::write_file,
@@ -22,6 +28,7 @@ pub fn run() {
             commands::recent::add_recent_file,
             commands::recent::clear_recent_files,
             commands::file_ops::get_open_file_arg,
+            commands::file_ops::get_pending_open_file,
             #[cfg(desktop)]
             platform::desktop::watch_file,
             #[cfg(desktop)]
@@ -47,12 +54,23 @@ pub fn run() {
         .expect("error building Inkwell")
         .run(|app_handle, event| {
             if let tauri::RunEvent::Opened { urls } = event {
-                for url in urls {
-                    if let Ok(path) = url.to_file_path() {
-                        if let Some(path_str) = path.to_str() {
-                            let _ = app_handle.emit("open-file-requested", path_str.to_string());
-                        }
-                    }
+                let paths: Vec<String> = urls
+                    .iter()
+                    .filter_map(|url| url.to_file_path().ok())
+                    .filter_map(|p| p.to_str().map(String::from))
+                    .collect();
+
+                if paths.is_empty() {
+                    return;
+                }
+
+                // Try to emit to frontend (works when app is already running).
+                // Also store in state for cold-launch (frontend polls on init).
+                let state = app_handle.state::<PendingOpenFiles>();
+                let mut pending = state.0.lock().unwrap();
+                for path in &paths {
+                    pending.push(path.clone());
+                    let _ = app_handle.emit("open-file-requested", path.clone());
                 }
             }
         });

--- a/src/main.js
+++ b/src/main.js
@@ -57,18 +57,24 @@ async function init() {
     document.getElementById("status-version").textContent = `v${version}`;
   } catch {}
 
-  // Check if app was launched with a file argument (file association / "Open With")
-  const fileArg = await invoke("get_open_file_arg");
-  if (fileArg) {
-    await loadFile(fileArg);
-  } else {
-    await showWelcome();
-  }
-
-  // Handle macOS file-open events (double-click / "Open With" file associations)
+  // Handle macOS file-open events for when the app is already running
+  // (registered early so no events are missed during the checks below)
   await listen("open-file-requested", async (event) => {
     await loadFile(event.payload);
   });
+
+  // Check if app was launched with a file argument
+  // 1. CLI argv (Linux/Windows file associations)
+  // 2. macOS Apple Events buffered in AppState (RunEvent::Opened fires before webview is ready)
+  const fileArg = await invoke("get_open_file_arg");
+  const pendingFile = !fileArg ? await invoke("get_pending_open_file") : null;
+  const openPath = fileArg || pendingFile;
+
+  if (openPath) {
+    await loadFile(openPath);
+  } else {
+    await showWelcome();
+  }
 }
 
 // --- File operations ---

--- a/src/main.js
+++ b/src/main.js
@@ -64,6 +64,11 @@ async function init() {
   } else {
     await showWelcome();
   }
+
+  // Handle macOS file-open events (double-click / "Open With" file associations)
+  await listen("open-file-requested", async (event) => {
+    await loadFile(event.payload);
+  });
 }
 
 // --- File operations ---

--- a/src/preview/scroll-sync.js
+++ b/src/preview/scroll-sync.js
@@ -2,6 +2,12 @@
 let editorScroller = null;
 let previewEl = null;
 let syncSource = null;
+let syncResetTimer = null;
+
+function deferSyncReset() {
+  clearTimeout(syncResetTimer);
+  syncResetTimer = setTimeout(() => { syncSource = null; }, 200);
+}
 
 export function setupScrollSync(editorView, previewElement) {
   editorScroller = editorView.scrollDOM;
@@ -17,7 +23,7 @@ export function setupScrollSync(editorView, previewElement) {
       const previewMax = previewEl.scrollHeight - previewEl.clientHeight;
       previewEl.scrollTop = ratio * previewMax;
     }
-    requestAnimationFrame(() => { syncSource = null; });
+    deferSyncReset();
   });
 
   // Preview -> Editor
@@ -30,7 +36,7 @@ export function setupScrollSync(editorView, previewElement) {
       const editorMax = editorScroller.scrollHeight - editorScroller.clientHeight;
       editorScroller.scrollTop = ratio * editorMax;
     }
-    requestAnimationFrame(() => { syncSource = null; });
+    deferSyncReset();
   });
 }
 
@@ -65,5 +71,5 @@ export function applyScrollRatio(ratio, targetMode) {
     previewEl.scrollTop = ratio * max;
   }
 
-  requestAnimationFrame(() => { syncSource = null; });
+  deferSyncReset();
 }

--- a/src/preview/scroll-sync.js
+++ b/src/preview/scroll-sync.js
@@ -58,7 +58,9 @@ export function getScrollRatio(activeMode) {
   return 0;
 }
 
-// Apply a scroll ratio to the target pane(s), suppressing sync feedback
+// Apply a scroll ratio to the target pane(s), suppressing sync feedback.
+// Uses a single requestAnimationFrame guard (not the 200ms debounce) since
+// this is a one-shot restore that shouldn't block user scroll input.
 export function applyScrollRatio(ratio, targetMode) {
   syncSource = "restore";
 
@@ -71,5 +73,5 @@ export function applyScrollRatio(ratio, targetMode) {
     previewEl.scrollTop = ratio * max;
   }
 
-  deferSyncReset();
+  requestAnimationFrame(() => { syncSource = null; });
 }


### PR DESCRIPTION
## Summary
- **Issue #1**: Fix double-click / "Open With" not opening files on macOS. The app only checked `argv` for file paths, but macOS uses Apple Events (`kAEOpenDocuments`) for file associations. Switched from `builder.run()` to `builder.build().run()` with a `RunEvent::Opened` handler that emits `open-file-requested` to the frontend. The existing `get_open_file_arg` remains as a fallback for Linux/Windows.
- **Issue #2**: Fix scroll feedback loop causing editor to drift back up when scrolling with mouse wheel. Replaced single-frame `requestAnimationFrame` sync guard with a 200ms debounced `setTimeout`, preventing the bounce-back caused by macOS's asynchronous scroll event delivery.

Closes #1, Closes #2

## Test plan
- [ ] On macOS, double-click a `.md` file in Finder — Inkwell should open and display the file
- [ ] On macOS, right-click a `.md` file → "Open With" → Inkwell — file should open
- [ ] Drag-and-drop still works as before
- [ ] In split view with a long document, scroll down with mouse wheel — editor should not drift back up
- [ ] Switching between editor/split/preview modes preserves scroll position
- [ ] On Linux/Windows, opening via CLI argument still works (argv fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)