### PR TITLE
Add pane swap control with persisted split layout preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Inkwell is built with [Tauri](https://tauri.app), which uses your system's nativ
 ### Split editor + rendered preview
 <img src="assets/editing.gif" alt="Split view editing" width="600">
 
-- **Split editor + preview** — Write Markdown on the left, see rendered output on the right. Scroll sync keeps both panes aligned.
+- **Split editor + preview** — Write Markdown in one pane and see rendered output in the other. Scroll sync keeps both panes aligned.
 - **Syntax highlighting** — Powered by CodeMirror 6 with full Markdown grammar support.
 - **Light & dark themes** — Toggle with one click, or follow your system preference.
 - **File associations** — Double-click any `.md` file on your system to open it directly in Inkwell.
@@ -57,6 +57,7 @@ Inkwell is built with [Tauri](https://tauri.app), which uses your system's nativ
 - **Word count & cursor position** — Always visible in the status bar.
 - **Recent files** — Quick access to your last 20 files from the welcome screen.
 - **Resizable split pane** — Drag the divider to adjust editor/preview ratio.
+- **Pane swap button** — Click the ⇄ button at the top of the divider to swap editor/preview sides.
 - **GFM support** — Tables, task lists, strikethrough, and fenced code blocks render correctly.
 - **Responsive layout** — Adapts to narrow windows automatically.
 

--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,9 @@
       </div>
       <div id="main-content">
         <div id="editor-pane"></div>
-        <div id="divider"></div>
+        <div id="divider">
+          <button id="btn-swap-panes" title="Swap panes" aria-label="Swap panes">&#x21C4;</button>
+        </div>
         <div id="preview-pane">
           <div id="preview-content"></div>
         </div>

--- a/src/state/app-state.js
+++ b/src/state/app-state.js
@@ -4,6 +4,7 @@ export const state = {
   isDirty: false,
   theme: "system",
   viewMode: "split",
+  panesSwapped: false,
   _listeners: new Map(),
 
   set(key, value) {

--- a/src/state/settings.js
+++ b/src/state/settings.js
@@ -9,6 +9,11 @@ export async function loadSettings() {
     if (savedTheme) {
       state.set("theme", savedTheme);
     }
+
+    const savedPaneSwap = localStorage.getItem("inkwell-panes-swapped");
+    if (savedPaneSwap !== null) {
+      state.set("panesSwapped", savedPaneSwap === "true");
+    }
   } catch {
     // localStorage may not be available in some contexts
   }
@@ -17,6 +22,14 @@ export async function loadSettings() {
 export function saveTheme(theme) {
   try {
     localStorage.setItem("inkwell-theme", theme);
+  } catch {
+    // Silently fail
+  }
+}
+
+export function savePaneSwap(swapped) {
+  try {
+    localStorage.setItem("inkwell-panes-swapped", String(swapped));
   } catch {
     // Silently fail
   }

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -81,11 +81,31 @@
 }
 
 #divider {
+  position: relative;
   width: 5px;
   background: var(--border);
   cursor: col-resize;
   flex-shrink: 0;
   transition: background 0.15s;
+}
+
+#btn-swap-panes {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 1px 3px;
+  font-size: 14px;
+  -webkit-text-stroke: 0.35px currentColor;
+  line-height: 1;
+  border: 1px solid var(--border);
+  background: var(--bg-toolbar);
+  color: var(--text-muted);
+  z-index: 1;
+}
+
+#btn-swap-panes:hover {
+  color: var(--text-primary);
 }
 
 #divider:hover,
@@ -97,6 +117,18 @@
   flex: 1;
   overflow-y: auto;
   background: var(--bg-preview);
+}
+
+#app.panes-swapped #preview-pane {
+  order: 1;
+}
+
+#app.panes-swapped #divider {
+  order: 2;
+}
+
+#app.panes-swapped #editor-pane {
+  order: 3;
 }
 
 #preview-content {

--- a/src/ui/divider.js
+++ b/src/ui/divider.js
@@ -1,14 +1,32 @@
+import { state } from "../state/app-state.js";
+import { savePaneSwap } from "../state/settings.js";
+
 // Draggable split pane divider
 export function setupDivider() {
+  const app = document.getElementById("app");
   const divider = document.getElementById("divider");
+  const swapButton = document.getElementById("btn-swap-panes");
   const editorPane = document.getElementById("editor-pane");
   const previewPane = document.getElementById("preview-pane");
   const mainContent = document.getElementById("main-content");
 
   let isDragging = false;
 
+  app.classList.toggle("panes-swapped", state.panesSwapped);
+
+  swapButton.addEventListener("click", togglePaneSwap);
+  swapButton.addEventListener("mousedown", (e) => e.stopPropagation());
+  swapButton.addEventListener("touchstart", (e) => e.stopPropagation(), { passive: true });
+
   divider.addEventListener("mousedown", startDrag);
   divider.addEventListener("touchstart", startDrag, { passive: false });
+
+  function togglePaneSwap() {
+    const swapped = !state.panesSwapped;
+    app.classList.toggle("panes-swapped", swapped);
+    state.set("panesSwapped", swapped);
+    savePaneSwap(swapped);
+  }
 
   function startDrag(e) {
     e.preventDefault();
@@ -40,11 +58,17 @@ export function setupDivider() {
 
       // Clamp between 20% and 80%
       const ratio = Math.max(0.2, Math.min(0.8, offset / total));
+      const swapped = state.panesSwapped;
 
       editorPane.style.flex = "none";
       previewPane.style.flex = "none";
-      editorPane.style.width = `${ratio * 100}%`;
-      previewPane.style.width = `${(1 - ratio) * 100}%`;
+      if (swapped) {
+        previewPane.style.width = `${ratio * 100}%`;
+        editorPane.style.width = `${(1 - ratio) * 100}%`;
+      } else {
+        editorPane.style.width = `${ratio * 100}%`;
+        previewPane.style.width = `${(1 - ratio) * 100}%`;
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- Add a small swap button (`⇄`) at the top of the split-pane divider to switch editor/preview sides.
- Persist pane swap preference across restarts using the existing frontend localStorage settings pattern.
- Keep divider drag-resize behavior correct after swapping by mapping ratio to the visible left/right panes.
- Update README to document the new swap control.

<img width="1201" height="803" alt="Screenshot 2026-04-21 at 14 05 18" src="https://github.com/user-attachments/assets/bd182cbb-1bd5-41b6-838e-8ab97b0c166f" />

## Why
I have dual vertical monitors and wanted to edit on the screen directly in front of me, while the preview was on the screen to my left. Other people may also prefer to edit on the right.

## Implementation Notes
- Added `panesSwapped` state in app state.
- Loaded/saved `inkwell-panes-swapped` in settings.
- Added swap button to divider UI.
- Applied swapped pane ordering via CSS class on `#app`.
- Updated divider drag width assignment logic for swapped mode.

## Validation
- `npm run build` passes successfully.

- Manually verified:
  - swap toggles pane sides,
  - preference persists after restart,
  - drag resize behaves correctly in both swapped and default layouts.